### PR TITLE
Unit suite

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,12 @@ test {
     systemProperties['lang'] = System.properties["lang"]
     systemProperties['host'] = System.properties["host"]
     maxParallelForks = 4
-    useTestNG()
+
+    def groupsToExclude = []
+    groupsToExclude.add('unit')
+    useTestNG() {
+        groupsToExclude.each { String group -> excludeGroups group }
+    }
 }
 
 task debug(type: Test) {
@@ -50,10 +55,13 @@ task debug(type: Test) {
     systemProperties['host'] = System.properties["host"]
     maxParallelForks = 4
 
+    def groupsToExclude = []
+    groupsToExclude.add('unit')
     def groupsToInclude = []
     groupsToInclude.add('under_development')
     useTestNG() {
         groupsToInclude.each { String group -> includeGroups group }
+        groupsToExclude.each { String group -> excludeGroups group }
     }
 }
 
@@ -64,10 +72,13 @@ task evt(type: Test) {
     systemProperties['host'] = System.properties["host"]
     maxParallelForks = 4
 
+    def groupsToExclude = []
+    groupsToExclude.add('unit')
     def groupsToInclude = []
     groupsToInclude.add('evt')
     useTestNG() {
         groupsToInclude.each { String group -> includeGroups group }
+        groupsToExclude.each { String group -> excludeGroups group }
     }
 }
 
@@ -78,11 +89,14 @@ task bvt(type: Test) {
     systemProperties['host'] = System.properties["host"]
     maxParallelForks = 4
 
+    def groupsToExclude = []
+    groupsToExclude.add('unit')
     def groupsToInclude = []
     groupsToInclude.add('evt')
     groupsToInclude.add('under_development')
     useTestNG() {
         groupsToInclude.each { String group -> includeGroups group }
+        groupsToExclude.each { String group -> excludeGroups group }
     }
 }
 
@@ -93,10 +107,13 @@ task sprint(type: Test) {
     systemProperties['host'] = System.properties["host"]
     maxParallelForks = 4
 
+    def groupsToExclude = []
+    groupsToExclude.add('unit')
     def groupsToInclude = []
     groupsToInclude.add('sprint')
     useTestNG() {
         groupsToInclude.each { String group -> includeGroups group }
+        groupsToExclude.each { String group -> excludeGroups group }
     }
 }
 
@@ -107,10 +124,13 @@ task release(type: Test) {
     systemProperties['host'] = System.properties["host"]
     maxParallelForks = 4
 
+    def groupsToExclude = []
+    groupsToExclude.add('unit')
     def groupsToInclude = []
     groupsToInclude.add('release')
     useTestNG() {
         groupsToInclude.each { String group -> includeGroups group }
+        groupsToExclude.each { String group -> excludeGroups group }
     }
 }
 
@@ -121,18 +141,23 @@ task production(type: Test) {
     systemProperties['host'] = System.properties["host"]
     maxParallelForks = 4
 
+    def groupsToExclude = []
+    groupsToExclude.add('unit')
     def groupsToInclude = []
     groupsToInclude.add('production')
     useTestNG() {
         groupsToInclude.each { String group -> includeGroups group }
+        groupsToExclude.each { String group -> excludeGroups group }
     }
 }
 
-task regression(type: Test) {
-    description = "All tests"
-    systemProperties['env'] = System.properties["env"]
-    systemProperties['lang'] = System.properties["lang"]
-    systemProperties['host'] = System.properties["host"]
+task unit(type: Test) {
+    description = "Unit tests"
     maxParallelForks = 4
-    useTestNG()
+
+    def groupsToInclude = []
+    groupsToInclude.add('unit')
+    useTestNG() {
+        groupsToInclude.each { String group -> includeGroups group }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ group 'com.softwareonpurpose'
 apply plugin: 'java'
 
 sourceCompatibility = 11
-version '1.2.5'
+version '1.2.6'
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ group 'com.softwareonpurpose'
 apply plugin: 'java'
 
 sourceCompatibility = 11
-version '1.2.6'
+version '1.3.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/softwareonpurpose/gauntlet/GauntletTest.java
+++ b/src/main/java/com/softwareonpurpose/gauntlet/GauntletTest.java
@@ -158,6 +158,7 @@ public abstract class GauntletTest {
         public static final String PRODUCTION = "production";   //  Benign (alters NO source data) executable in Production
         public static final String RELEASE = "release";         //  Test critical to validating Release Readiness
         public static final String SPRINT = "sprint";           //  Validates acceptance criteria for current sprint
+        public static final String UNIT = "unit";               //  Unit tests of Software Gauntlet classes
     }
 
     /**

--- a/src/test/java/com/softwareonpurpose/gauntlet/EnvironmentIntegrationTest.java
+++ b/src/test/java/com/softwareonpurpose/gauntlet/EnvironmentIntegrationTest.java
@@ -3,7 +3,7 @@ package com.softwareonpurpose.gauntlet;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@Test(enabled = false)
+@Test(groups={GauntletTest.TestSuite.UNIT})
 public class EnvironmentIntegrationTest {
     public void smoke() {
         Environment.clear();

--- a/src/test/java/com/softwareonpurpose/gauntlet/EnvironmentUnitTest.java
+++ b/src/test/java/com/softwareonpurpose/gauntlet/EnvironmentUnitTest.java
@@ -6,7 +6,7 @@ import org.testng.annotations.Test;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
-@Test(enabled = false)
+@Test(groups={GauntletTest.TestSuite.UNIT})
 public class EnvironmentUnitTest {
     public void getKeyFromUninitializedEnvironment() {
         String expected = null;

--- a/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountMultiTestMultiExecNodeCalibratorTest.java
+++ b/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountMultiTestMultiExecNodeCalibratorTest.java
@@ -7,7 +7,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-@Test(enabled = false)
+@Test(groups={GauntletTest.TestSuite.UNIT})
 public class VerifyCountMultiTestMultiExecNodeCalibratorTest extends GauntletTest {
     @DataProvider
     public static Object[][] scenarios_test1() {
@@ -27,7 +27,7 @@ public class VerifyCountMultiTestMultiExecNodeCalibratorTest extends GauntletTes
         };
     }
 
-    @Test(enabled = false, dataProvider = "scenarios_test1")
+    @Test(dataProvider = "scenarios_test1")
     public void verificationCount_multipleExecutions_test1(long expected) {
         AnObjectExpected expectedObject = AnObjectExpected.getInstance();
         AnObject actualObject = AnObject.getInstance();
@@ -37,7 +37,7 @@ public class VerifyCountMultiTestMultiExecNodeCalibratorTest extends GauntletTes
         Assert.assertEquals(actual, expected, "FAILED to calculate accurate verification count");
     }
 
-    @Test(enabled = false, dataProvider = "scenarios_test2")
+    @Test(dataProvider = "scenarios_test2")
     public void verificationCount_multipleExecutions_test2(long expected) {
         AnObjectExpected expectedObject = AnObjectExpected.getInstance();
         AnObject actualObject = AnObject.getInstance();

--- a/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountMultiTestMultiExecParCalibratorTest.java
+++ b/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountMultiTestMultiExecParCalibratorTest.java
@@ -5,7 +5,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-@Test(enabled = false)
+@Test(groups=GauntletTest.TestSuite.UNIT)
 public class VerifyCountMultiTestMultiExecParCalibratorTest extends GauntletTest {
     @DataProvider
     public static Object[][] scenarios_test1() {
@@ -25,7 +25,7 @@ public class VerifyCountMultiTestMultiExecParCalibratorTest extends GauntletTest
         };
     }
 
-    @Test(enabled = false, dataProvider = "scenarios_test1")
+    @Test(dataProvider = "scenarios_test1")
     public void verificationCount_multipleExecutionsTest1(long expected) {
         AnObjectExpected expectedObject = AnObjectExpected.getInstance();
         AnObject actualObject = AnObject.getInstance();
@@ -37,7 +37,7 @@ public class VerifyCountMultiTestMultiExecParCalibratorTest extends GauntletTest
         Assert.assertEquals(actual, expected, "FAILED to calculate accurate verification count");
     }
 
-    @Test(enabled = false, dataProvider = "scenarios_test2")
+    @Test(dataProvider = "scenarios_test2")
     public void verificationCount_multipleExecutionsTest2(long expected) {
         AnObjectExpected expectedObject = AnObjectExpected.getInstance();
         AnObject actualObject = AnObject.getInstance();

--- a/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountMultiTestSingleExecNodeCalibratorTest.java
+++ b/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountMultiTestSingleExecNodeCalibratorTest.java
@@ -6,9 +6,9 @@ import com.softwareonpurpose.gauntlet.anobject.AnObjectExpected;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@Test(enabled = false)
+@Test(groups={GauntletTest.TestSuite.UNIT})
 public class VerifyCountMultiTestSingleExecNodeCalibratorTest extends GauntletTest {
-    @Test(enabled = false)
+    @Test()
     public void verificationCount_testMethodOne() {
         AnObjectExpected expectedObject = AnObjectExpected.getInstance();
         AnObject actualObject = AnObject.getInstance();
@@ -19,7 +19,7 @@ public class VerifyCountMultiTestSingleExecNodeCalibratorTest extends GauntletTe
         Assert.assertEquals(actual, expected, "FAILED to calculate accurate verification count");
     }
 
-    @Test(enabled = false, dependsOnMethods = "verificationCount_testMethodOne")
+    @Test(dependsOnMethods = "verificationCount_testMethodOne")
     public void verificationCount_testMethodTwo() {
         AnObjectExpected expectedObject = AnObjectExpected.getInstance();
         AnObject actualObject = AnObject.getInstance();

--- a/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountMultiTestSingleExecNodeCalibratorTest.java
+++ b/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountMultiTestSingleExecNodeCalibratorTest.java
@@ -8,7 +8,6 @@ import org.testng.annotations.Test;
 
 @Test(groups={GauntletTest.TestSuite.UNIT})
 public class VerifyCountMultiTestSingleExecNodeCalibratorTest extends GauntletTest {
-    @Test()
     public void verificationCount_testMethodOne() {
         AnObjectExpected expectedObject = AnObjectExpected.getInstance();
         AnObject actualObject = AnObject.getInstance();

--- a/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountMultiTestSingleExecParCalibratorTest.java
+++ b/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountMultiTestSingleExecParCalibratorTest.java
@@ -4,9 +4,8 @@ import com.softwareonpurpose.gauntlet.anobject.*;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@Test(enabled = false)
+@Test(groups = {GauntletTest.TestSuite.UNIT})
 public class VerifyCountMultiTestSingleExecParCalibratorTest extends GauntletTest {
-    @Test(enabled = false)
     public void verificationCount_testMethodOneExecution() {
         AnObjectExpected expectedObject = AnObjectExpected.getInstance();
         AnObject actualObject = AnObject.getInstance();
@@ -19,7 +18,6 @@ public class VerifyCountMultiTestSingleExecParCalibratorTest extends GauntletTes
         Assert.assertEquals(actual, expected, "FAILED to calculate accurate verification count");
     }
 
-    @Test(enabled = false)
     public void verificationCount_testMethodTwoExecution() {
         AnObjectExpected expectedObject = AnObjectExpected.getInstance();
         AnObject actualObject = AnObject.getInstance();

--- a/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountSingleTestMultiExecNodeCalibratorTest.java
+++ b/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountSingleTestMultiExecNodeCalibratorTest.java
@@ -7,7 +7,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-@Test(enabled = false)
+@Test(groups={GauntletTest.TestSuite.UNIT})
 public class VerifyCountSingleTestMultiExecNodeCalibratorTest extends GauntletTest {
     @DataProvider
     public static Object[][] scenarios() {
@@ -18,7 +18,7 @@ public class VerifyCountSingleTestMultiExecNodeCalibratorTest extends GauntletTe
         };
     }
 
-    @Test(enabled = false, dataProvider = "scenarios")
+    @Test(dataProvider = "scenarios")
     public void verificationCount_multipleExecutions(long expected) {
         AnObjectExpected expectedObject = AnObjectExpected.getInstance();
         AnObject actualObject = AnObject.getInstance();

--- a/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountSingleTestMultiExecParCalibratorTest.java
+++ b/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountSingleTestMultiExecParCalibratorTest.java
@@ -5,7 +5,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-@Test(enabled = false)
+@Test(groups={GauntletTest.TestSuite.UNIT})
 public class VerifyCountSingleTestMultiExecParCalibratorTest extends GauntletTest {
     @DataProvider
     public static Object[][] scenarios() {
@@ -16,7 +16,7 @@ public class VerifyCountSingleTestMultiExecParCalibratorTest extends GauntletTes
         };
     }
 
-    @Test(enabled = false, dataProvider = "scenarios")
+    @Test(dataProvider = "scenarios")
     public void verificationCount_multipleExecutions(long expected) {
         AnObjectExpected expectedObject = AnObjectExpected.getInstance();
         AnObject actualObject = AnObject.getInstance();

--- a/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountSingleTestSingleExecNodeCalibratorTest.java
+++ b/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountSingleTestSingleExecNodeCalibratorTest.java
@@ -6,9 +6,8 @@ import com.softwareonpurpose.gauntlet.anobject.AnObjectExpected;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@Test(enabled = false)
+@Test(groups={GauntletTest.TestSuite.UNIT})
 public class VerifyCountSingleTestSingleExecNodeCalibratorTest extends GauntletTest {
-    @Test(enabled = false)
     public void verificationCount_singleTestMethodExecution() {
         AnObjectExpected expectedObject = AnObjectExpected.getInstance();
         AnObject actualObject = AnObject.getInstance();

--- a/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountSingleTestSingleExecParCalibratorTest.java
+++ b/src/test/java/com/softwareonpurpose/gauntlet/VerifyCountSingleTestSingleExecParCalibratorTest.java
@@ -4,9 +4,8 @@ import com.softwareonpurpose.gauntlet.anobject.*;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-@Test(enabled = false)
+@Test(groups={GauntletTest.TestSuite.UNIT})
 public class VerifyCountSingleTestSingleExecParCalibratorTest extends GauntletTest {
-    @Test(enabled = false)
     public void verificationCount_singleTestMethodExecution() {
         AnObjectExpected expectedObject = AnObjectExpected.getInstance();
         AnObject actualObject = AnObject.getInstance();


### PR DESCRIPTION
Add 'Unit' as a test suite, adding Software Gauntlet unit tests to that suite, and excluding the 'Unit' suite from all other test suites.

This avoids the risk of accidentally running Software Gauntlet tests as part of the testing of another system, and allows for excluding them without using the 'enabled=false' @Test annotation.